### PR TITLE
Mutator

### DIFF
--- a/scripts/mutator.py
+++ b/scripts/mutator.py
@@ -4,10 +4,13 @@ Mutator Script
 Performs random deletions on the codebase
 """
 
-# TODO: Implement mutation logic
 import os
 import random
 import pathspec
+import sys
+
+from utils.mutation_utils import roll_mutation
+from utils.context_utils import MutationContext
 
 MUTIGNORE_PATH = ".mutignore"
 
@@ -31,27 +34,69 @@ def get_all_files(directory):
             file_list.append(os.path.join(directory, full_path))
     return file_list
 
-def mini_mut(file_path):
-    # Deletes random line in given file.
+def regular_mutation(file_path, flavor, ctx):
+    # Deletes a random number of lines from one file.
+    # Severity of line deletion (number of blocks, number of lines within blocks) is determined by flavor (conservative, medium or crazy).
     with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
-        lines = f.readlines()
-    if not lines:
-        return None
+        file_lines = f.readlines()
+    if not file_lines:
+        print("No lines to delete.")
+        return
 
-    idx = random.randint(0, len(lines) - 1)
-    removed_line = lines.pop(idx)
+    mutation_spec = roll_mutation(flavor, file_lines)
+    blocks = sorted(mutation_spec['blocks'], key=lambda b: b['start_line'], reverse=True)
 
-    with open(file_path, 'w', encoding='utf-8') as f:
-        f.writelines(lines)
+    for block in blocks:
+        start = block['start_line'] - 1
+        count = block['lines_to_delete']
+        file_lines[start:start + count] = ['#mutator_was_here\n']
+        ctx.add_mutation(
+            file_path=file_path,
+            start_line=block['start_line'],
+            deleted_line_count=count
+        )
 
-def run_mutation(directory):
+    with open(file_path, 'w') as f:
+        f.writelines(file_lines)
+
+def mega_mutation(file_path, ctx):
+    # Deletes entire file.
+    with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+        file_lines = f.readlines()
+    if not file_lines:
+        print("No lines to delete.")
+        return
+
+    try:
+        os.remove(file_path)
+        ctx.add_mutation(
+            file_path=file_path,
+            start_line=1,
+            deleted_line_count=len(file_lines)
+        )
+    except Exception:
+        return
+
+def run_mutation(directory, flavor):
     files = get_all_files(directory)
     if not files:
         print("No files to mutate.")
         return
 
+    ctx = MutationContext(config={"flavor": flavor})
     target = random.choice(files)
-    mini_mut(target)
+    if flavor != 'pure_and_utter_madness':
+        regular_mutation(target, flavor, ctx)
+    else:
+        mega_mutation(target, ctx)
+    
+    ctx.save()
+    print(f"Mutation context saved as .mutation-context.json")
 
 if __name__ == "__main__":
-    run_mutation(".")
+    if len(sys.argv) < 2:
+        print("Usage: python mutator.py <flavor>")
+        sys.exit(1)
+
+    flavor = sys.argv[1]
+    run_mutation(".", flavor)

--- a/scripts/mutator.py
+++ b/scripts/mutator.py
@@ -43,7 +43,7 @@ def regular_mutation(file_path, flavor, ctx):
         print("No lines to delete.")
         return
 
-    mutation_spec = roll_mutation(flavor, file_lines)
+    mutation_spec = roll_mutation(flavor, len(file_lines))
     blocks = sorted(mutation_spec['blocks'], key=lambda b: b['start_line'], reverse=True)
 
     for block in blocks:


### PR DESCRIPTION
# Summary
Updated ```mutator.py``` to make use of the ```roll_mutation``` function and ```MutationContext``` class defined in ```mutation_utils.py``` and ```context_utils.py``` respectively.

```mutator.py``` now defines two mutation functions, ```regular_mutation``` and ```mega_mutation```, and the deletions they perform are recorded in an instance of the ```MutationContext``` class.

### ```regular_mutation```
This function accepts 3 parameters, these being
- the file_path of the file it is mutating,
- the flavor of mutation, and
- the (empty) mutation context.

Line deletions are then performed by first calling ```roll_mutation``` to obtain the mutation specification, passing ```flavor``` and the target file's line count, and the deletions/mutations recorded in ```ctx```, the mutation context created in ```run_mutation```.

### ```mega_mutation```
This function accepts 2 parameters, these being
- the file_path of the file it is mutating, and
- the (empty) mutation context.

This function is called if the user-specified flavor is ```'pure_and_utter_madness'``` and deletes the entire file, recording this mutation in ```ctx```.

## Note:
We require an update to the ```mutate.yml``` file, adding

```yaml
env:
    MUTATION_FLAVOR: medium
```

and updating

```yaml
steps:
    {...}
    - name: Run scripts/mutator.py
      run: python scripts/mutator.py $MUTATION_FLAVOR
```
to allow users to set their desired mutation flavor (conservative, medium, crazy and pure_and_utter_madness) via GitHub secrets.  If this isn't set, the value will default to ```'medium'```.